### PR TITLE
Fix code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/src/sections/DappPage/DappPageRating.tsx
+++ b/src/sections/DappPage/DappPageRating.tsx
@@ -53,9 +53,8 @@ const DappPageRating = ({ dappKey = "my_dapp" }: Props) => {
   const determineIfMainnet = () => {
     if (typeof window !== "undefined") {
       const { hostname } = window.location
-      return (
-        hostname.includes("dappland.com") || hostname.includes("substack.com")
-      )
+      const allowedHosts = ["dappland.com", "substack.com"]
+      return allowedHosts.some(allowedHost => hostname === allowedHost || hostname.endsWith(`.${allowedHost}`))
     } else {
       return false
     }


### PR DESCRIPTION
Fixes [https://github.com/VersoriumX/Dappland-X/security/code-scanning/3](https://github.com/VersoriumX/Dappland-X/security/code-scanning/3)

To fix the problem, we need to replace the substring check with a more robust method. Specifically, we should parse the URL and use an explicit whitelist of allowed hosts. This ensures that only the exact allowed hosts or their subdomains are accepted.

1. Parse the URL to extract the hostname.
2. Use an explicit whitelist of allowed hosts to check if the hostname is valid.
3. Update the `determineIfMainnet` function to implement these changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
